### PR TITLE
Add session creation endpoint

### DIFF
--- a/app/api/session/route.ts
+++ b/app/api/session/route.ts
@@ -1,0 +1,39 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { adminAuth } from "@/lib/firebase-admin"
+
+export async function POST(request: NextRequest) {
+  try {
+    const { idToken } = await request.json()
+
+    if (typeof idToken !== "string" || !idToken) {
+      return NextResponse.json({ error: "ID token is required" }, { status: 400 })
+    }
+
+    // Verify the ID token and create a session cookie
+    const decoded = await adminAuth.verifyIdToken(idToken)
+    const expiresIn = 60 * 60 * 24 * 7 * 1000 // 7 days in milliseconds
+    const sessionCookie = await adminAuth.createSessionCookie(idToken, { expiresIn })
+
+    const response = NextResponse.json({
+      success: true,
+      user: {
+        uid: decoded.uid,
+        email: decoded.email,
+        name: decoded.name,
+        picture: decoded.picture,
+      },
+    })
+
+    response.cookies.set("__session", sessionCookie, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      maxAge: 60 * 60 * 24 * 7, // 7 days
+    })
+
+    return response
+  } catch (error) {
+    console.error("Session creation error:", error)
+    return NextResponse.json({ error: "Failed to create session" }, { status: 401 })
+  }
+}


### PR DESCRIPTION
## Summary
- implement `app/api/session/route.ts` that verifies an ID token via Firebase Admin
- create a 7‑day `__session` cookie and return the authenticated user info

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run build` *(fails: duplicate route conflict)*

------
https://chatgpt.com/codex/tasks/task_e_687dcf8fdbf08325be73e5b74a2a472c