### PR TITLE
Add session route and resolve register duplication

### DIFF
--- a/app/(auth)/complete-register/page.tsx
+++ b/app/(auth)/complete-register/page.tsx
@@ -5,12 +5,11 @@ import { useRouter } from "next/navigation"
 import { useForm } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import * as z from "zod"
-import { UserAuth } from "@/context/AuthContext"
+import { useAuth } from "@/contexts/auth-context"
 import { Button } from "@/components/ui/button"
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
 import { toast } from "sonner"
-import { createUserProfile } from "@/lib/actions/user.actions"
 
 const formSchema = z.object({
   firstName: z.string().min(2, {
@@ -24,7 +23,7 @@ const formSchema = z.object({
 const RegisterPage = () => {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const router = useRouter()
-  const { createUser } = UserAuth()
+  const { signUp } = useAuth()
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -45,17 +44,13 @@ const RegisterPage = () => {
         return
       }
 
-      const { user } = await createUser(email, password)
+      const result = await signUp(email, password, {
+        firstName: values.firstName,
+        lastName: values.lastName,
+        email,
+      })
 
-      if (user) {
-        await createUserProfile({
-          userId: user.uid,
-          firstName: values.firstName,
-          lastName: values.lastName,
-          email: user.email || "",
-          profileImageUrl: user.photoURL || "",
-        })
-
+      if (result.user) {
         toast.success("Account created!")
         await router.replace("/dashboard")
       } else {

--- a/app/api/session/route.ts
+++ b/app/api/session/route.ts
@@ -1,0 +1,39 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { adminAuth } from "@/lib/firebase-admin"
+
+export async function POST(request: NextRequest) {
+  try {
+    const { idToken } = await request.json()
+
+    if (typeof idToken !== "string" || !idToken) {
+      return NextResponse.json({ error: "ID token is required" }, { status: 400 })
+    }
+
+    // Verify the ID token and create a session cookie
+    const decoded = await adminAuth.verifyIdToken(idToken)
+    const expiresIn = 60 * 60 * 24 * 7 * 1000 // 7 days in milliseconds
+    const sessionCookie = await adminAuth.createSessionCookie(idToken, { expiresIn })
+
+    const response = NextResponse.json({
+      success: true,
+      user: {
+        uid: decoded.uid,
+        email: decoded.email,
+        name: decoded.name,
+        picture: decoded.picture,
+      },
+    })
+
+    response.cookies.set("__session", sessionCookie, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      maxAge: 60 * 60 * 24 * 7, // 7 days
+    })
+
+    return response
+  } catch (error) {
+    console.error("Session creation error:", error)
+    return NextResponse.json({ error: "Failed to create session" }, { status: 401 })
+  }
+}


### PR DESCRIPTION
## Summary
- implement `app/api/session/route.ts` to verify ID tokens and set a session cookie
- rename `(auth)/register` page to `(auth)/complete-register` to avoid route clash
- update registration logic to use the existing `useAuth` hook

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687dcf8fdbf08325be73e5b74a2a472c