### PR TITLE
Add protected test endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ FIREBASE_PRIVATE_KEY=<firebase service account private key>
 
 The public variables (prefixed with `NEXT_PUBLIC_`) are required both on the client and the server. The remaining variables are used only on the server when initializing Firebase Admin.
 
+This project requires **Node.js 18** or later and uses `pnpm` for dependency management.
+
 ## Running the app
 
 Install dependencies and start the development server:

--- a/app/api/protected/test/route.ts
+++ b/app/api/protected/test/route.ts
@@ -1,0 +1,21 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { adminAuth } from "@/lib/firebase-admin";
+
+export async function GET(request: NextRequest) {
+  const sessionCookie = request.cookies.get("__session")?.value;
+  if (!sessionCookie) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const decoded = await adminAuth.verifySessionCookie(sessionCookie, true);
+    return NextResponse.json({
+      success: true,
+      uid: decoded.uid,
+      email: decoded.email,
+    });
+  } catch (error) {
+    console.error("Protected route auth error:", error);
+    return NextResponse.json({ error: "Invalid session" }, { status: 401 });
+  }
+}


### PR DESCRIPTION
## Summary
- add an API route at `/api/protected/test` that verifies the session cookie
- document Node.js 18 requirement in README

## Testing
- `pnpm build`
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_687dba3de8d4832584a2b9636e21f13d