### PR TITLE
Add node middleware setting

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,9 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  experimental: {
+    nodeMiddleware: true,
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
## Summary
- allow Node.js middleware by enabling `experimental.nodeMiddleware` in Next.js config

## Testing
- `pnpm lint` *(fails: experimental feature requires canary Next.js)*
- `pnpm build` *(fails: experimental feature requires canary Next.js)*

------
https://chatgpt.com/codex/tasks/task_e_687e8c78842083259a13ef44b7adea41