### PR TITLE
Remove obsolete Next.js node middleware option

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,10 +8,7 @@ const nextConfig = {
   },
   images: {
     unoptimized: true,
-  },
-  experimental: {
-    nodeMiddleware: true,
-  },
+  }
 }
 
 export default nextConfig


### PR DESCRIPTION
## Summary
- clean up `next.config.mjs` by removing deprecated `experimental.nodeMiddleware`

## Testing
- `pnpm build`
- `pnpm dev` (terminated after startup)


------
https://chatgpt.com/codex/tasks/task_e_687e9b1ff1148325a315b5af087cf3d3