### PR TITLE
Fix verify-session cookie retrieval

### DIFF
--- a/app/api/verify-session/route.ts
+++ b/app/api/verify-session/route.ts
@@ -3,7 +3,8 @@ import { cookies } from "next/headers"
 import { adminAuth } from "@/lib/firebase-admin"
 
 export async function GET() {
-  const sessionCookie = cookies().get("__session")?.value
+  const cookieStore = await cookies()
+  const sessionCookie = cookieStore.get("__session")?.value
   if (!sessionCookie) {
     return NextResponse.json({ authenticated: false }, { status: 401 })
   }


### PR DESCRIPTION
## Summary
- adjust cookie retrieval in API route to support async cookies

## Testing
- `npx tsc --noEmit` *(fails: contexts/app-state-context.tsx types)*

------
https://chatgpt.com/codex/tasks/task_e_687e9b2193388325a1b44dea33b31f50