### PR TITLE
Add vitest testing setup

### DIFF
--- a/__tests__/example.test.ts
+++ b/__tests__/example.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest'
+
+describe('math', () => {
+  it('adds numbers', () => {
+    expect(1 + 1).toBe(2)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "next build",
     "dev": "next dev",
     "lint": "next lint",
-    "start": "next start"
+    "start": "next start",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "5.1.1",
@@ -44,6 +45,7 @@
     "date-fns": "4.1.0",
     "embla-carousel-react": "8.5.1",
     "firebase": "12.0.0",
+    "firebase-admin": "^13.4.0",
     "input-otp": "1.4.1",
     "lucide-react": "^0.454.0",
     "next": "15.2.4",
@@ -57,8 +59,7 @@
     "sonner": "2.0.6",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^3.24.1",
-    "firebase-admin": "^13.4.0"
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@types/node": "^22",
@@ -68,6 +69,7 @@
     "eslint-config-next": "^15.4.2",
     "postcss": "^8.5",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^3.2.4"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
## Summary
- install `vitest` and Node 20 to run tests
- configure `vitest`
- add `npm test` script
- provide example test under `__tests__/`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ea1e6b3488325b14d20db6a14eccc