### PR TITLE
Fix project type usage

### DIFF
--- a/app/(dashboard)/contractor/projects/page.tsx
+++ b/app/(dashboard)/contractor/projects/page.tsx
@@ -7,23 +7,8 @@ import { useEffect } from "react"
 import { Button } from "@/components/ui/button"
 import Link from "next/link"
 import { PlusCircle } from "lucide-react"
+import type { Project } from "@/lib/firebase-services"
 
-interface DashboardProject {
-  id: string
-  title: string
-  client?: string
-  address?: string
-  startDate?: string
-  endDate?: string
-  status?: string
-  progress?: number
-  totalCost?: number
-  paidAmount?: number
-  description?: string
-  imageUrl?: string
-  downloadURL?: string
-  storagePath?: string
-}
 
 export default function ContractorProjectsPage() {
   const { state } = useAppState()
@@ -40,7 +25,7 @@ export default function ContractorProjectsPage() {
   }
 
   // In a real app, this would be filtered to show only projects assigned to the contractor.
-  const projects = (state.projects || []) as DashboardProject[]
+  const projects = state.projects || []
 
   return (
     <div className="space-y-6">
@@ -57,7 +42,7 @@ export default function ContractorProjectsPage() {
       {projects.length > 0 ? (
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
           {projects.map((project) => (
-            <ProjectCard key={project.id} project={project as DashboardProject} />
+            <ProjectCard key={project.id} project={project} />
           ))}
         </div>
       ) : (

--- a/app/(dashboard)/new-project/page.tsx
+++ b/app/(dashboard)/new-project/page.tsx
@@ -13,11 +13,13 @@ import { ChevronLeft } from "lucide-react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { useAppState } from "@/contexts/app-state-context"
+import { useAuth } from "@/contexts/auth-context"
 import { useToast } from "@/components/ui/use-toast"
 import type { Project } from "@/lib/firebase-services"
 
 export default function NewProjectPage() {
   const router = useRouter()
+  const { user } = useAuth()
   const { addProject, state } = useAppState()
   const { toast } = useToast()
   const [formData, setFormData] = useState({
@@ -60,23 +62,40 @@ export default function NewProjectPage() {
       return
     }
 
-    // Create new project
-    const newProject = {
+    // Create new project data including required Project fields
+    const selectedClient = state.clients.find(
+      (c) => c.name === formData.client,
+    )
+
+    const newProject: Project & {
+      client?: string
+      address?: string
+      startDate?: string
+      endDate?: string
+      progress: number
+      totalCost: number
+      paidAmount: number
+    } = {
       id: `${Date.now()}`,
       title: formData.title,
+      description: formData.description,
+      status: "pending",
+      budget: Number.parseFloat(formData.budget),
+      clientId: selectedClient?.id || "",
+      contractorId: user?.uid || "",
+      createdAt: new Date(),
+      updatedAt: new Date(),
       client: formData.client,
       address: formData.address,
       startDate: formData.startDate,
       endDate: formData.endDate,
-      status: "pending",
       progress: 0,
       totalCost: Number.parseFloat(formData.budget),
       paidAmount: 0,
-      description: formData.description,
     }
 
     // Add project to state
-    addProject(newProject as Project)
+    addProject(newProject)
 
     // Show success toast
     toast({

--- a/components/project-card.tsx
+++ b/components/project-card.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import type React from "react"
+import type { Project } from "@/lib/firebase-services"
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
@@ -11,18 +12,14 @@ import { useRouter } from "next/navigation"
 import { useAppState } from "@/contexts/app-state-context"
 
 interface ProjectCardProps {
-  project: {
-    id: string
-    title: string
-    client: string
-    address: string
-    startDate: string
-    endDate: string
-    status: string
-    progress: number
-    totalCost: number
-    paidAmount: number
-    description?: string
+  project: Project & {
+    client?: string
+    address?: string
+    startDate?: string
+    endDate?: string
+    progress?: number
+    totalCost?: number
+    paidAmount?: number
     imageUrl?: string
     downloadURL?: string
     storagePath?: string


### PR DESCRIPTION
## Summary
- use `Project` type in `ProjectCard`
- load projects without local casting
- create new projects with required fields

## Testing
- `npx tsc --noEmit`
- `npm test` *(runs vitest)*

------
https://chatgpt.com/codex/tasks/task_e_687eaa4234a48325929c34e494ebc32e