### PR TITLE
Add nodeMiddleware experiment

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  experimental: {
+    nodeMiddleware: true,
+  },
   eslint: {
     ignoreDuringBuilds: true,
   },


### PR DESCRIPTION
## Summary
- enable experimental nodeMiddleware in Next.js config

## Testing
- `pnpm build` *(fails: nodeMiddleware requires canary version)*

------
https://chatgpt.com/codex/tasks/task_e_687fb299a0088325a597b54dd5835841