### PR TITLE
Type projectData and simplify newProject creation

### DIFF
--- a/app/(dashboard)/new-project/page.tsx
+++ b/app/(dashboard)/new-project/page.tsx
@@ -67,13 +67,19 @@ export default function NewProjectPage() {
       (c) => c.name === formData.client,
     )
 
-    const projectData = {
+    const projectData: Project = {
+      id: "",
       title: formData.title,
       description: formData.description,
       status: "pending",
       budget: Number.parseFloat(formData.budget),
       clientId: selectedClient?.id || "",
       contractorId: user?.uid || "",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    }
+
+    const extendedData = {
       client: formData.client,
       address: formData.address,
       startDate: formData.startDate,
@@ -84,20 +90,12 @@ export default function NewProjectPage() {
     }
 
     try {
-      const projectId = await createProject(projectData)
-      const newProject: Project & {
-        client?: string
-        address?: string
-        startDate?: string
-        endDate?: string
-        progress: number
-        totalCost: number
-        paidAmount: number
-      } = {
+      const { id: _id, ...createData } = { ...projectData, ...extendedData }
+      const projectId = await createProject(createData)
+      const newProject = {
         ...projectData,
+        ...extendedData,
         id: projectId,
-        createdAt: new Date(),
-        updatedAt: new Date(),
       }
 
       // Add project to state with the returned id


### PR DESCRIPTION
## Summary
- type `projectData` as `Project`
- construct `newProject` from typed data without casting

## Testing
- `pnpm lint` *(fails: experimental.nodeMiddleware requires next@canary)*

------
https://chatgpt.com/codex/tasks/task_e_687fd3d3e24c8325aabc23134c57ba78