### PR TITLE
Fix logout cookie path

### DIFF
--- a/app/api/logout/route.ts
+++ b/app/api/logout/route.ts
@@ -9,6 +9,7 @@ export async function POST() {
     secure: process.env.NODE_ENV === "production",
     sameSite: "lax",
     maxAge: 0,
+    path: "/",
   })
 
   return response


### PR DESCRIPTION
## Summary
- ensure logout cookie path is explicitly set to `/`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688073b5ca6c83258d6cf50b320c1820