### PR TITLE
docs: add local development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 This project is a Next.js application that relies on Firebase for authentication and data storage.
 
+## Run locally
+
+1. Ensure you have **Node.js 18** or later installed.
+2. Install dependencies:
+
+   ```bash
+   pnpm install
+   ```
+
+3. Create a `.env.local` file with the Firebase variables described in the [Configuration](#configuration) section.
+4. Start the development server:
+
+   ```bash
+   pnpm dev
+   ```
+
+5. Optionally, run `firebase emulators:start` to launch local Firebase services.
+
 ## Configuration
 
 The app expects several Firebase credentials to be present in your environment. Create a `.env.local` file in the project root and add the following variables:
@@ -22,31 +40,11 @@ FIREBASE_PRIVATE_KEY=<firebase service account private key>
 
 The public variables (prefixed with `NEXT_PUBLIC_`) are required both on the client and the server. The remaining variables are used only on the server when initializing Firebase Admin.
 
-This project requires **Node.js 18** or later and uses `pnpm` for dependency management.
-
-## Running the app
-
-Install dependencies and start the development server:
-
-```bash
-pnpm install
-pnpm dev
-```
-
 The utility in `lib/env.client.ts` and `lib/env.server.ts` validates these variables at startup using [Zod](https://github.com/colinhacks/zod). If any are missing, the application will throw an error during initialization.
-
-## Local Firebase Emulators
-
-To test Firebase services locally, install the Firebase CLI and run:
-
-```bash
-firebase emulators:start
-```
-
-This command reads `.firebaserc` for the project ID and uses the ports defined in `firebase.json`.
 
 To deploy the Firestore and Storage rules to your Firebase project, run:
 
 ```bash
 firebase deploy --only firestore,storage
 ```
+


### PR DESCRIPTION
## Summary
- document how to run the app locally, including Node.js 18+, installing dependencies, creating `.env.local`, and starting the dev server
- mention `firebase emulators:start` for local Firebase services

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a54c65e3f08325a2c55965277bf1bd